### PR TITLE
Update setup_utils.py on gbk error decoding winget info

### DIFF
--- a/physiolabxr/utils/setup_utils.py
+++ b/physiolabxr/utils/setup_utils.py
@@ -306,7 +306,7 @@ def add_to_path(new_path):
 
 
 def add_protoc_to_path_windows():
-    winget_info = subprocess.run(["winget", "--info"], capture_output=True, text=True).stdout
+    winget_info = subprocess.run(["winget", "--info"], capture_output=True, text=True, encoding='utf-8').stdout
     winget_info = winget_info.splitlines()
     winget_info = [x for x in winget_info if 'Portable Package Root (User)' in x][0]
     winget_info = re.sub(r'\s+', ' ', winget_info).split(' ')[-1]


### PR DESCRIPTION
added decoder as 'utf-8' for correct decoding of data
fix for Error induced by decoder codec 'gbk' since it cannot correctly decode winget info, and change it to 'utf-8' fixed the issue

`UnicodeDecodeError: 'gbk' codec can't decode byte 0xa6 in position 498: illegal multibyte sequence
Traceback (most recent call last):
  File "C:\Users\92310\Code\PhysioLabXR-Community\physiolabxr\PhysioLabXR.py", line 10, in <module>
    physiolabxr()
  File "C:\Users\92310\Code\PhysioLabXR-Community\physiolabxr\__init__.py", line 35, in physiolabxr
    run_setup_check()
  File "C:\Users\92310\Code\PhysioLabXR-Community\physiolabxr\utils\setup_utils.py", line 453, in run_setup_check
    setup_grpc_csharp_plugin()
  File "C:\Users\92310\Code\PhysioLabXR-Community\physiolabxr\utils\setup_utils.py", line 394, in setup_grpc_csharp_plugin
    add_protoc_to_path_windows()
  File "C:\Users\92310\Code\PhysioLabXR-Community\physiolabxr\utils\setup_utils.py", line 310, in add_protoc_to_path_windows
    winget_info = winget_info.splitlines()`